### PR TITLE
fix: 프로그램 제공일지 페이지 프로그램 리스트 표시 문제 해결

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -190,11 +190,17 @@ function showPage(pageName) {
         progressSection.style.display = 'none';
     }
 
-    // 프로그램 일지 페이지로 이동 시 자동완성 설정
-    if (pageName === 'program-log' && typeof setupProgramAutocomplete === 'function') {
+    // 프로그램 일지 페이지로 이동 시 자동완성 설정 및 프로그램 리스트 채우기
+    if (pageName === 'program-log') {
         // 약간의 딜레이 후 설정 (DOM이 완전히 렌더링된 후)
         setTimeout(() => {
-            setupProgramAutocomplete();
+            if (typeof setupProgramAutocomplete === 'function') {
+                setupProgramAutocomplete();
+            }
+            // 프로그램 제공일지의 프로그램 선택 드롭다운 채우기
+            if (typeof toggleProgramMode === 'function') {
+                toggleProgramMode();
+            }
         }, 100);
     }
 


### PR DESCRIPTION
프로그램 제공일지 페이지로 이동 시 프로그램 선택 드롭다운이 비어있던 문제 수정.
showPage 함수에서 program-log 페이지 로드 시 toggleProgramMode 함수를 호출하여 프로그램 리스트가 자동으로 채워지도록 개선.