### PR TITLE
feat: 청구 준비에 '일정 확인' 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,11 @@
                             <div class="absolute left-2.5 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-gray-300 dark:bg-gray-600 submenu-dot"></div>
                             어르신 시간확인
                         </a>
+                        <a href="#" id="nav-schedule-verification" onclick="showPage('schedule-verification'); return false;" class="submenu-link relative pl-8 pr-3 py-2.5 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:text-primary hover:bg-primary/5 dark:hover:text-primary transition-colors flex items-center gap-2">
+                            <div class="absolute left-3.5 top-0 bottom-0 w-px bg-gray-200 dark:bg-gray-600"></div>
+                            <div class="absolute left-2.5 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-gray-300 dark:bg-gray-600 submenu-dot"></div>
+                            일정 확인
+                        </a>
                     </div>
                 </div>
 
@@ -1404,6 +1409,111 @@
                     </div>
                 </div>
 
+                <!-- Schedule Verification Page -->
+                <div id="page-schedule-verification" class="page-hidden">
+                    <div class="flex flex-col gap-2 mb-6">
+                        <h1 class="text-2xl font-bold text-gray-900 dark:text-white tracking-tight">일정 확인</h1>
+                        <p class="text-gray-500 dark:text-gray-400 mt-1">공단 일정과 입퇴소 내용을 비교하여 결석 및 일정 없는 출석을 확인합니다.</p>
+                    </div>
+
+                    <!-- 파일 업로드 섹션 -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 mb-6">
+                        <h3 class="text-base font-bold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+                            <span class="material-symbols-outlined text-primary">upload_file</span>
+                            파일 업로드 (3개 필수)
+                        </h3>
+
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                            <!-- 수급자 목록 -->
+                            <div class="flex flex-col">
+                                <label class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">① 수급자 목록</label>
+                                <button onclick="document.getElementById('sv-master-input').click()" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2.5 rounded-lg font-medium text-sm shadow hover:shadow-md transition-all flex items-center justify-center gap-2">
+                                    <span class="material-symbols-outlined text-lg">person</span>
+                                    수급자 목록 파일 선택
+                                </button>
+                                <input type="file" id="sv-master-input" accept=".xlsx,.xls" style="display: none;" onchange="handleScheduleFile(this, 'master')">
+                                <div id="sv-master-status" class="mt-2 text-xs"></div>
+                            </div>
+
+                            <!-- 일정계획 -->
+                            <div class="flex flex-col">
+                                <label class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">② 일정계획 (공단)</label>
+                                <button onclick="document.getElementById('sv-schedule-input').click()" class="bg-green-500 hover:bg-green-600 text-white px-4 py-2.5 rounded-lg font-medium text-sm shadow hover:shadow-md transition-all flex items-center justify-center gap-2">
+                                    <span class="material-symbols-outlined text-lg">calendar_month</span>
+                                    일정계획 파일 선택
+                                </button>
+                                <input type="file" id="sv-schedule-input" accept=".xlsx,.xls" style="display: none;" onchange="handleScheduleFile(this, 'schedule')">
+                                <div id="sv-schedule-status" class="mt-2 text-xs"></div>
+                            </div>
+
+                            <!-- 입퇴소내용 -->
+                            <div class="flex flex-col">
+                                <label class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">③ 입퇴소내용</label>
+                                <button onclick="document.getElementById('sv-attendance-input').click()" class="bg-amber-500 hover:bg-amber-600 text-white px-4 py-2.5 rounded-lg font-medium text-sm shadow hover:shadow-md transition-all flex items-center justify-center gap-2">
+                                    <span class="material-symbols-outlined text-lg">fact_check</span>
+                                    입퇴소내용 파일 선택
+                                </button>
+                                <input type="file" id="sv-attendance-input" accept=".xlsx,.xls" style="display: none;" onchange="handleScheduleFile(this, 'attendance')">
+                                <div id="sv-attendance-status" class="mt-2 text-xs"></div>
+                            </div>
+                        </div>
+
+                        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+                            <h4 class="text-sm font-bold text-blue-900 dark:text-blue-200 mb-2">📋 파일 형식 안내</h4>
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-xs text-blue-800 dark:text-blue-300">
+                                <div>
+                                    <p class="font-semibold mb-1">수급자 목록:</p>
+                                    <ul class="list-disc list-inside space-y-0.5">
+                                        <li>수급자명, 생년월일, 인정번호</li>
+                                    </ul>
+                                </div>
+                                <div>
+                                    <p class="font-semibold mb-1">일정계획 (공단):</p>
+                                    <ul class="list-disc list-inside space-y-0.5">
+                                        <li>A열: 일자 (yyyy-mm-dd)</li>
+                                        <li>D열: 이름</li>
+                                        <li>수급자 인정번호 컬럼</li>
+                                    </ul>
+                                </div>
+                                <div>
+                                    <p class="font-semibold mb-1">입퇴소내용:</p>
+                                    <ul class="list-disc list-inside space-y-0.5">
+                                        <li>A열: 이름, B열: 생년키</li>
+                                        <li>C열: 일자, E열: 입퇴소구분</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 분석 실행 버튼 -->
+                    <div class="flex justify-center mb-6">
+                        <button onclick="runScheduleVerification()" class="bg-primary hover:bg-primary-dark text-white px-8 py-3 rounded-lg font-semibold text-base shadow-lg hover:shadow-xl transition-all flex items-center gap-2">
+                            <span class="material-symbols-outlined">compare_arrows</span>
+                            일정 비교 실행
+                        </button>
+                    </div>
+
+                    <!-- 결과 출력 -->
+                    <div id="sv-result-section" class="hidden">
+                        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6">
+                            <div class="flex items-center justify-between mb-4">
+                                <h3 class="text-base font-bold text-gray-900 dark:text-white flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-primary">assignment</span>
+                                    비교 결과
+                                </h3>
+                                <button onclick="copyScheduleResult()" class="text-primary hover:text-primary-dark text-sm font-medium flex items-center gap-1">
+                                    <span class="material-symbols-outlined text-lg">content_copy</span>
+                                    결과 복사
+                                </button>
+                            </div>
+
+                            <div id="sv-result-content" class="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4 font-mono text-sm whitespace-pre-wrap">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Settings Page -->
                 <div id="page-settings" class="page-hidden">
                     <div class="flex flex-col gap-2 mb-8">
@@ -1728,6 +1838,7 @@
     <script src="js/monitoring.js"></script>
     <script src="js/vehicle-checker.js"></script>
     <script src="js/elder-time-checker.js"></script>
+    <script src="js/schedule-verification.js"></script>
     <script src="js/main.js"></script>
 
     <!-- 인증 체크 -->

--- a/js/schedule-verification.js
+++ b/js/schedule-verification.js
@@ -1,0 +1,480 @@
+/**
+ * schedule-verification.js
+ * 일정 확인 기능 - 공단 일정과 입퇴소 내용 비교
+ */
+
+// Global state
+let svMasterData = null;      // 수급자 목록
+let svScheduleData = null;    // 일정계획 (공단)
+let svAttendanceData = null;  // 입퇴소내용
+
+/**
+ * 이름 정규화: 모든 공백 제거 + trim
+ */
+function normalizeName(name) {
+    if (!name) return '';
+    return String(name).replace(/\s+/g, '').trim();
+}
+
+/**
+ * 날짜 정규화: yyyy-mm-dd 또는 다양한 형식 -> yyyymmdd
+ */
+function normalizeDate(dateVal) {
+    if (!dateVal) return '';
+    let str = String(dateVal).trim();
+
+    // 숫자만 추출
+    const digitsOnly = str.replace(/[^0-9]/g, '');
+
+    // 이미 8자리면 그대로 반환
+    if (digitsOnly.length === 8) {
+        return digitsOnly;
+    }
+
+    // yyyy-mm-dd 또는 yyyy.mm.dd 형식
+    const match = str.match(/(\d{4})[-./](\d{1,2})[-./](\d{1,2})/);
+    if (match) {
+        const year = match[1];
+        const month = match[2].padStart(2, '0');
+        const day = match[3].padStart(2, '0');
+        return year + month + day;
+    }
+
+    return digitsOnly;
+}
+
+/**
+ * 생년월일을 yymmdd로 변환
+ * yyyy.mm.dd, yyyy-mm-dd, yyyymmdd 등 -> yymmdd
+ */
+function normalizeBirthKey(birthVal) {
+    if (!birthVal) return '';
+    let str = String(birthVal).trim();
+
+    // 숫자만 추출
+    const digitsOnly = str.replace(/[^0-9]/g, '');
+
+    // 이미 6자리면 그대로 반환
+    if (digitsOnly.length === 6) {
+        return digitsOnly;
+    }
+
+    // 8자리 (yyyymmdd)면 앞 2자리(yy) 추출
+    if (digitsOnly.length === 8) {
+        return digitsOnly.substring(2, 8);
+    }
+
+    // yyyy.mm.dd 또는 yyyy-mm-dd 형식
+    const match = str.match(/(\d{4})[-./](\d{1,2})[-./](\d{1,2})/);
+    if (match) {
+        const year = match[1].substring(2, 4);
+        const month = match[2].padStart(2, '0');
+        const day = match[3].padStart(2, '0');
+        return year + month + day;
+    }
+
+    return digitsOnly;
+}
+
+/**
+ * 날짜를 YYYY-MM-DD 형식으로 변환
+ */
+function formatDateForDisplay(yyyymmdd) {
+    if (!yyyymmdd || yyyymmdd.length !== 8) return yyyymmdd;
+    return `${yyyymmdd.substring(0, 4)}-${yyyymmdd.substring(4, 6)}-${yyyymmdd.substring(6, 8)}`;
+}
+
+/**
+ * 입퇴소구분 정규화: 출석 여부 판단
+ */
+function isPresent(status) {
+    if (!status) return false;
+    const s = String(status).trim();
+    return s === '입퇴소' || s === '출석';
+}
+
+/**
+ * 엑셀 파일 처리
+ */
+function handleScheduleFile(input, type) {
+    const file = input.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+
+    reader.onload = function(e) {
+        try {
+            const data = new Uint8Array(e.target.result);
+            const workbook = XLSX.read(data, { type: 'array' });
+
+            // 첫 번째 시트 사용
+            const sheetName = workbook.SheetNames[0];
+            const worksheet = workbook.Sheets[sheetName];
+            const jsonData = XLSX.utils.sheet_to_json(worksheet, { header: 'A', defval: '' });
+
+            let statusElementId, dataVar, displayName;
+
+            switch (type) {
+                case 'master':
+                    statusElementId = 'sv-master-status';
+                    svMasterData = jsonData;
+                    displayName = '수급자 목록';
+                    break;
+                case 'schedule':
+                    statusElementId = 'sv-schedule-status';
+                    svScheduleData = jsonData;
+                    displayName = '일정계획';
+                    break;
+                case 'attendance':
+                    statusElementId = 'sv-attendance-status';
+                    svAttendanceData = jsonData;
+                    displayName = '입퇴소내용';
+                    break;
+            }
+
+            document.getElementById(statusElementId).innerHTML = `
+                <div class="text-green-600 dark:text-green-400 flex items-center gap-1">
+                    <span class="material-symbols-outlined text-sm">check_circle</span>
+                    ${file.name} (${jsonData.length - 1}행)
+                </div>
+            `;
+
+        } catch (error) {
+            alert(`파일 처리 중 오류가 발생했습니다:\n${error.message}`);
+            input.value = '';
+        }
+    };
+
+    reader.readAsArrayBuffer(file);
+}
+
+/**
+ * 수급자 목록에서 헤더 행 찾기 및 매핑 생성
+ * person_key (이름|생년키) -> 인정번호
+ */
+function buildMasterMap(masterData) {
+    const personToId = new Map();  // person_key -> Set of 인정번호
+
+    // 헤더 행 찾기: "수급자명", "생년월일", "인정번호" 컬럼이 있는 행
+    let headerRowIdx = -1;
+    let nameColIdx = -1;
+    let birthColIdx = -1;
+    let idColIdx = -1;
+
+    const colLetters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O'];
+
+    for (let i = 0; i < Math.min(masterData.length, 20); i++) {
+        const row = masterData[i];
+        for (let j = 0; j < colLetters.length; j++) {
+            const cellVal = String(row[colLetters[j]] || '').trim();
+            if (cellVal.includes('수급자명') || cellVal === '성명' || cellVal === '이름') {
+                nameColIdx = j;
+            }
+            if (cellVal.includes('생년월일')) {
+                birthColIdx = j;
+            }
+            if (cellVal.includes('인정번호')) {
+                idColIdx = j;
+            }
+        }
+
+        if (nameColIdx >= 0 && birthColIdx >= 0 && idColIdx >= 0) {
+            headerRowIdx = i;
+            break;
+        }
+    }
+
+    if (headerRowIdx === -1) {
+        throw new Error('수급자 목록에서 헤더 행(수급자명, 생년월일, 인정번호)을 찾을 수 없습니다.');
+    }
+
+    // 데이터 행 처리
+    for (let i = headerRowIdx + 1; i < masterData.length; i++) {
+        const row = masterData[i];
+        const name = normalizeName(row[colLetters[nameColIdx]]);
+        const birthRaw = row[colLetters[birthColIdx]];
+        const birthKey = normalizeBirthKey(birthRaw);
+        const recognitionId = String(row[colLetters[idColIdx]] || '').trim();
+
+        if (!name || !birthKey || !recognitionId) continue;
+
+        const personKey = `${name}|${birthKey}`;
+
+        if (!personToId.has(personKey)) {
+            personToId.set(personKey, new Set());
+        }
+        personToId.get(personKey).add(recognitionId);
+    }
+
+    return personToId;
+}
+
+/**
+ * 공단 일정에서 인정번호 컬럼 찾기
+ */
+function findRecognitionIdColumn(scheduleData) {
+    if (!scheduleData || scheduleData.length === 0) return -1;
+
+    const colLetters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'];
+
+    // 첫 몇 행에서 "수급자 인정번호" 또는 "인정번호" 헤더 찾기
+    for (let i = 0; i < Math.min(scheduleData.length, 10); i++) {
+        const row = scheduleData[i];
+        for (let j = 0; j < colLetters.length; j++) {
+            const cellVal = String(row[colLetters[j]] || '').replace(/\s+/g, '').trim();
+            if (cellVal.includes('인정번호')) {
+                return j;
+            }
+        }
+    }
+
+    return -1;
+}
+
+/**
+ * 일정 비교 실행
+ */
+async function runScheduleVerification() {
+    // 파일 체크
+    if (!svMasterData || !svScheduleData || !svAttendanceData) {
+        alert('3개의 파일을 모두 업로드해주세요.');
+        return;
+    }
+
+    showLoadingOverlay('일정 비교 중...');
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    try {
+        // 1. 수급자 목록에서 person_key -> 인정번호 매핑 생성
+        const personToIdMap = buildMasterMap(svMasterData);
+
+        // 2. 입퇴소 데이터 처리
+        const attendanceRecords = [];
+        const mappingErrors = {
+            notFound: [],  // {date, name, birthKey}
+            ambiguous: []  // {name, birthKey, candidates: []}
+        };
+
+        // 헤더 행 건너뛰기 (첫 번째 행)
+        for (let i = 1; i < svAttendanceData.length; i++) {
+            const row = svAttendanceData[i];
+            const name = normalizeName(row.A);
+            const birthKey = String(row.B || '').trim();  // yymmdd 그대로 사용
+            const dateRaw = String(row.C || '').trim();
+            const status = String(row.E || '').trim();
+
+            if (!name || !dateRaw) continue;
+
+            const dateNorm = normalizeDate(dateRaw);
+            const personKey = `${name}|${birthKey}`;
+
+            // 인정번호 매핑
+            if (!personToIdMap.has(personKey)) {
+                mappingErrors.notFound.push({ date: dateNorm, name, birthKey });
+                continue;
+            }
+
+            const idSet = personToIdMap.get(personKey);
+            if (idSet.size > 1) {
+                mappingErrors.ambiguous.push({ name, birthKey, candidates: Array.from(idSet) });
+                continue;
+            }
+
+            const recognitionId = Array.from(idSet)[0];
+            const present = isPresent(status);
+
+            attendanceRecords.push({
+                recognitionId,
+                date: dateNorm,
+                name,
+                birthKey,
+                present
+            });
+        }
+
+        // 3. 공단 일정 처리
+        const scheduleRecords = [];
+        const idColIdx = findRecognitionIdColumn(svScheduleData);
+        const colLetters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'];
+
+        if (idColIdx === -1) {
+            throw new Error('일정계획 파일에서 인정번호 컬럼을 찾을 수 없습니다.');
+        }
+
+        // 헤더 행 건너뛰기 (첫 번째 행)
+        for (let i = 1; i < svScheduleData.length; i++) {
+            const row = svScheduleData[i];
+            const dateRaw = String(row.A || '').trim();  // A열: 일자
+            const name = normalizeName(row.D);  // D열: 이름
+            const recognitionId = String(row[colLetters[idColIdx]] || '').trim();
+
+            if (!dateRaw || !recognitionId) continue;
+
+            const dateNorm = normalizeDate(dateRaw);
+
+            scheduleRecords.push({
+                recognitionId,
+                date: dateNorm,
+                name
+            });
+        }
+
+        // 4. 집합 생성
+        // SCHEDULE_SET: 공단 일정 KEY 집합
+        const scheduleSet = new Set();
+        const scheduleMap = new Map();  // KEY -> {name, date, recognitionId}
+
+        scheduleRecords.forEach(rec => {
+            const key = `${rec.recognitionId}|${rec.date}`;
+            scheduleSet.add(key);
+            scheduleMap.set(key, rec);
+        });
+
+        // ATT_ANY_SET: 입퇴소에서 출석/결석 관계없이 KEY 집합
+        const attAnySet = new Set();
+        const attAnyMap = new Map();
+
+        // ATT_PRESENT_SET: 입퇴소에서 출석인 것만
+        const attPresentSet = new Set();
+        const attPresentMap = new Map();
+
+        attendanceRecords.forEach(rec => {
+            const key = `${rec.recognitionId}|${rec.date}`;
+            attAnySet.add(key);
+            attAnyMap.set(key, rec);
+
+            if (rec.present) {
+                attPresentSet.add(key);
+                attPresentMap.set(key, rec);
+            }
+        });
+
+        // 5. 판정
+        // 결석: SCHEDULE_SET - ATT_ANY_SET
+        const absentKeys = [];
+        scheduleSet.forEach(key => {
+            if (!attAnySet.has(key)) {
+                absentKeys.push(key);
+            }
+        });
+
+        // 일정없는데 출석: ATT_PRESENT_SET - SCHEDULE_SET
+        const extraPresentKeys = [];
+        attPresentSet.forEach(key => {
+            if (!scheduleSet.has(key)) {
+                extraPresentKeys.push(key);
+            }
+        });
+
+        // 6. 결과 출력 생성
+        let result = '';
+
+        result += `결석 (공단 O / 입퇴소 X)\t${absentKeys.length}건\n`;
+        result += `일정없는데 출석 (공단 X / 입퇴소 O)\t${extraPresentKeys.length}건\n`;
+
+        // 일정없는데 출석 상세
+        if (extraPresentKeys.length > 0) {
+            result += `\n[일정없는데 출석 대상]\n`;
+            extraPresentKeys.sort().forEach(key => {
+                const rec = attPresentMap.get(key);
+                if (rec) {
+                    result += `- ${formatDateForDisplay(rec.date)} | ${rec.name} | 생년월일(키) ${rec.birthKey} | 인정번호 ${rec.recognitionId}\n`;
+                }
+            });
+        }
+
+        // 매핑오류 출력
+        result += `\n[매핑오류]\n`;
+
+        // NOT_FOUND
+        const notFoundCount = mappingErrors.notFound.length;
+        result += `- NOT_FOUND: ${notFoundCount}건`;
+        if (notFoundCount > 0) {
+            result += ` (`;
+            const uniqueNotFound = [];
+            const seenNF = new Set();
+            mappingErrors.notFound.forEach(nf => {
+                const key = `${nf.date}|${nf.name}|${nf.birthKey}`;
+                if (!seenNF.has(key)) {
+                    seenNF.add(key);
+                    uniqueNotFound.push(nf);
+                }
+            });
+            const top20NF = uniqueNotFound.slice(0, 20);
+            result += top20NF.map(nf => `${nf.date}|${nf.name}|${nf.birthKey}`).join(', ');
+            if (uniqueNotFound.length > 20) result += `, ...`;
+            result += `)`;
+        }
+        result += `\n`;
+
+        // AMBIGUOUS
+        const uniqueAmbiguous = [];
+        const seenAmb = new Set();
+        mappingErrors.ambiguous.forEach(amb => {
+            const key = `${amb.name}|${amb.birthKey}`;
+            if (!seenAmb.has(key)) {
+                seenAmb.add(key);
+                uniqueAmbiguous.push(amb);
+            }
+        });
+        const ambiguousCount = uniqueAmbiguous.length;
+        result += `- AMBIGUOUS: ${ambiguousCount}건`;
+        if (ambiguousCount > 0) {
+            result += ` (`;
+            const top20Amb = uniqueAmbiguous.slice(0, 20);
+            result += top20Amb.map(amb => `${amb.name}|${amb.birthKey}|[${amb.candidates.join(',')}]`).join(', ');
+            if (uniqueAmbiguous.length > 20) result += `, ...`;
+            result += `)`;
+        }
+        result += `\n`;
+
+        // 결과 표시
+        document.getElementById('sv-result-content').textContent = result;
+        document.getElementById('sv-result-section').classList.remove('hidden');
+
+        hideLoadingOverlay();
+
+    } catch (error) {
+        hideLoadingOverlay();
+        alert(`분석 중 오류가 발생했습니다:\n${error.message}`);
+        console.error(error);
+    }
+}
+
+/**
+ * 결과 복사
+ */
+function copyScheduleResult() {
+    const resultContent = document.getElementById('sv-result-content').textContent;
+
+    navigator.clipboard.writeText(resultContent).then(() => {
+        // 복사 성공 알림
+        const btn = document.querySelector('[onclick="copyScheduleResult()"]');
+        const originalHtml = btn.innerHTML;
+        btn.innerHTML = '<span class="material-symbols-outlined text-lg">check</span> 복사됨';
+        setTimeout(() => {
+            btn.innerHTML = originalHtml;
+        }, 2000);
+    }).catch(err => {
+        alert('클립보드 복사에 실패했습니다.');
+    });
+}
+
+/**
+ * 파일 초기화
+ */
+function resetScheduleVerification() {
+    svMasterData = null;
+    svScheduleData = null;
+    svAttendanceData = null;
+
+    document.getElementById('sv-master-input').value = '';
+    document.getElementById('sv-schedule-input').value = '';
+    document.getElementById('sv-attendance-input').value = '';
+
+    document.getElementById('sv-master-status').innerHTML = '';
+    document.getElementById('sv-schedule-status').innerHTML = '';
+    document.getElementById('sv-attendance-status').innerHTML = '';
+
+    document.getElementById('sv-result-section').classList.add('hidden');
+}


### PR DESCRIPTION
공단 일정과 입퇴소 내용을 비교하여 결석 및 일정 없는 출석을 확인하는 기능
- 3개 파일 업로드: 수급자 목록, 일정계획(공단), 입퇴소내용
- person_key(이름|생년키)로 인정번호 매핑
- 결석(공단 O / 입퇴소 X) 건수 표시
- 일정없는데 출석(공단 X / 입퇴소 O) 상세 목록 표시
- 매핑오류(NOT_FOUND, AMBIGUOUS) 출력

https://claude.ai/code/session_019qV9rWC3Gu44oYxBJAK9f4